### PR TITLE
Adds orionFiles to import/export functionality

### DIFF
--- a/exporter_server.js
+++ b/exporter_server.js
@@ -8,8 +8,9 @@ Picker.route('/admin/download-export/:key', function(params, req, res, next) {
   }
 
   var data = {};
-
+	
   data.dictionary = orion.dictionary.findOne();
+  data.orionFiles = orion.filesystem.collection.find().fetch();
   if (exportPages) {
     data.pages = pages.find().fetch();
   }
@@ -39,6 +40,10 @@ Picker.route('/admin/import-data/:key', function(params, req, res, next) {
     // import dictionary
     orion.dictionary.remove({});
     orion.dictionary.insert(data.dictionary);
+	
+	// import orionFiles
+	orion.filesystem.collection.remove({});
+	orion.filesystem.collection.insert(data.orionFiles, {validate: false});
 
     // import pages
     if (exportPages) {


### PR DESCRIPTION
This update allows for you to import the orionFiles colecition from orion.filesystem.collection, so that image and file data can be shared through exports.
